### PR TITLE
Use intermediate object to store confirmed matches within a penalty group and prevent infinite reactivation of Inherited virtualization rule (bsc#1094524)

### DIFF
--- a/src/main/java/com/suse/matcher/facts/ConfirmedMatchInPenaltyGroup.java
+++ b/src/main/java/com/suse/matcher/facts/ConfirmedMatchInPenaltyGroup.java
@@ -1,0 +1,104 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.matcher.facts;
+
+import org.apache.commons.lang3.builder.EqualsBuilder;
+import org.apache.commons.lang3.builder.HashCodeBuilder;
+import org.apache.commons.lang3.builder.ToStringBuilder;
+
+/**
+ * Representation of a confirmed match in a penalty group.
+ *
+ **/
+public class ConfirmedMatchInPenaltyGroup {
+
+    public long subscriptionId;
+    public int penaltyGroupId;
+    public long guestId;
+
+    /**
+     * Standard constructor.
+     *
+     * @param subscriptionIdIn - the subscription id
+     * @param penaltyGroupIdIn - the penalty group id
+     * @param guestIdIn - the guest id
+     */
+    public ConfirmedMatchInPenaltyGroup(Long subscriptionIdIn, int penaltyGroupIdIn, long guestIdIn) {
+        this.subscriptionId = subscriptionIdIn;
+        this.penaltyGroupId = penaltyGroupIdIn;
+        this.guestId = guestIdIn;
+    }
+
+    /**
+     * Gets the subscriptionId.
+     *
+     * @return subscriptionId
+     */
+    public Long getSubscriptionId() {
+        return subscriptionId;
+    }
+
+    /**
+     * Gets the penaltyGroupId.
+     *
+     * @return penaltyGroupId
+     */
+    public int getPenaltyGroupId() {
+        return penaltyGroupId;
+    }
+
+    /**
+     * Gets the guestId.
+     *
+     * @return guestId
+     */
+    public Long getGuestId() {
+        return guestId;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+        if (this == o) return true;
+
+        if (o == null || getClass() != o.getClass()) return false;
+
+        ConfirmedMatchInPenaltyGroup that = (ConfirmedMatchInPenaltyGroup) o;
+
+        return new EqualsBuilder()
+                .append(penaltyGroupId, that.penaltyGroupId)
+                .append(guestId, that.guestId)
+                .append(subscriptionId, that.subscriptionId)
+                .isEquals();
+    }
+
+    @Override
+    public int hashCode() {
+        return new HashCodeBuilder(17, 37)
+                .append(subscriptionId)
+                .append(penaltyGroupId)
+                .append(guestId)
+                .toHashCode();
+    }
+
+    @Override
+    public String toString() {
+        return new ToStringBuilder(this)
+                .append("subscriptionId", subscriptionId)
+                .append("penaltyGroupId", penaltyGroupId)
+                .append("guestId", guestId)
+                .toString();
+    }
+}

--- a/src/main/java/com/suse/matcher/facts/GroupInInheritedVirtualization.java
+++ b/src/main/java/com/suse/matcher/facts/GroupInInheritedVirtualization.java
@@ -1,0 +1,55 @@
+/**
+ * Copyright (c) 2018 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.matcher.facts;
+
+import org.kie.api.definition.type.PropertyReactive;
+
+/**
+ * Marker class expressing that a group of matches was generated from Inherited virtualization
+ * matches. This is to stop infinite re-activation.
+ */
+@PropertyReactive
+public class GroupInInheritedVirtualization {
+
+    private int groupId;
+
+    /**
+     * Standard constructor.
+     *
+     * @param groupIdIn - the group id
+     */
+    public GroupInInheritedVirtualization(int groupIdIn) {
+        this.groupId = groupIdIn;
+    }
+
+    /**
+     * Gets the groupId.
+     *
+     * @return groupId
+     */
+    public int getGroupId() {
+        return groupId;
+    }
+
+    /**
+     * Sets the groupId.
+     *
+     * @param groupIdIn - the groupId
+     */
+    public void setGroupId(int groupIdIn) {
+        groupId = groupIdIn;
+    }
+}

--- a/src/main/resources/com/suse/matcher/rules/drools/Matchability.drl
+++ b/src/main/resources/com/suse/matcher/rules/drools/Matchability.drl
@@ -4,6 +4,7 @@ import java.util.List;
 
 import com.suse.matcher.Drools;
 import com.suse.matcher.facts.CentGroup;
+import com.suse.matcher.facts.GroupInInheritedVirtualization;
 import com.suse.matcher.facts.HostGuest;
 import com.suse.matcher.facts.HostedProduct;
 import com.suse.matcher.facts.InstalledProduct;
@@ -110,6 +111,7 @@ rule "matchInheritedVirtualization"
             systemId == $systemId
         )
         CentGroup(id == $centGroupId, $cents : cents)
+        not GroupInInheritedVirtualization(groupId == $baseGroupId) // prevent infinite re-activation
     then
         int addonGroupId = Drools.generateId($baseGroupId, $addonSubscriptionId);
 
@@ -120,6 +122,7 @@ rule "matchInheritedVirtualization"
 
         insert(new CentGroup(baseMatchCentGroupId, $cents));
         insert(new CentGroup(addonMatchCentGroupId, $cents));
+        insert(new GroupInInheritedVirtualization(addonGroupId));
         insert(new PartialMatch($systemId, $baseProductId, $baseSubscriptionId, baseMatchCentGroupId, addonGroupId));
         insert(new PartialMatch($systemId, $addonProductId, $addonSubscriptionId, addonMatchCentGroupId, addonGroupId));
 end

--- a/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
+++ b/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
@@ -11,6 +11,7 @@ import com.suse.matcher.facts.Subscription;
 import com.suse.matcher.facts.System;
 import com.suse.matcher.facts.PenaltyGroup;
 import com.suse.matcher.facts.InstalledProduct;
+import com.suse.matcher.facts.ConfirmedMatchInPenaltyGroup;
 import com.suse.matcher.solver.Match;
 
 global HardSoftScoreHolder scoreHolder;
@@ -23,20 +24,26 @@ global HardSoftScoreHolder scoreHolder;
 
 rule "calculate12Penalties"
   when
-    PenaltyGroup($penaltyGroupId: id)
-    Subscription($subscriptionId : id, policy != null && policy == Policy.ONE_TWO, ignored == false)
-    accumulate (
-        // count the number of VMs that use a certain 1:2 subscription in one penalty group
-        PenaltyGroup($guestId : guestId, id == $penaltyGroupId) and
-        PartialMatch($groupId : groupId, systemId == $guestId, subscriptionId == $subscriptionId) and
-        Match(id == $groupId, confirmed == true);
-        $count : count();
-        // if it is odd...
-        ($count % 2) == 1
-    )
+    Subscription($subscriptionId : id, policy != null && policy == Policy.ONE_TWO, ignored == false) and
+    PenaltyGroup($penaltyGroupId: id, $guestId : guestId) and
+    PartialMatch($groupId : groupId, systemId == $guestId, subscriptionId == $subscriptionId) and
+    Match(id == $groupId, confirmed == true);
   then
-    // ...add a 50 cent penalty. This ensures a whole number of subscriptions is
-    // always used for the same penalty group
+    // insert a confirmed match for subscription, guest and penalty group
+    insertLogical(new ConfirmedMatchInPenaltyGroup($subscriptionId, $penaltyGroupId, $guestId));
+end
+
+rule "insert12Penalties"
+  when
+    Subscription($subscriptionId : id, policy != null && policy == Policy.ONE_TWO, ignored == false) and
+    PenaltyGroup($penaltyGroupId: id);
+    accumulate(
+      ConfirmedMatchInPenaltyGroup(subscriptionId == $subscriptionId, penaltyGroupId == $penaltyGroupId);
+      $count : count();
+      ($count % 2) == 1
+    );
+  then
+    // insert a 1-2 penalty when the number of confirmed matches in penalty group is odd
     insertLogical(new OneTwoPenalty($subscriptionId, $penaltyGroupId, 50));
 end
 


### PR DESCRIPTION


Previously, the big "accumulate" in calculate12Penalties was too slow
and didn't even finish on some setups.