### PR TITLE
Set core dumps location for IBM java (bsc#1107302)

### DIFF
--- a/utils/subscription-matcher
+++ b/utils/subscription-matcher
@@ -1,3 +1,6 @@
 #!/bin/bash
 
-exec java -cp $(build-classpath antlr-runtime-3 commons-io commons-lang commons-lang3 commons-math3 commons-cli commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal log4j mvel2 optaplanner-core slf4j/api slf4j/log4j12 xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G com.suse.matcher.Main "$@"
+EXTRA_ARGS=""
+java -version 2>&1 | grep IBM > /dev/null && { EXTRA_ARGS="-Xdump:heap:file=/var/crash/heapdump.%Y%m%d.%H%M%S.%pid.%seq.phd -Xdump:java:file=/var/crash/javacore.%Y%m%d.%H%M%S.%pid.%seq.txt -Xdump:snap:file=/var/crash/Snap.%Y%m%d.%H%M%S.%pid.%seq.trc -Xdump:system:file=/var/crash/core.%Y%m%d.%H%M%S.%pid.%seq.dmp"; }
+
+exec java -cp $(build-classpath antlr-runtime-3 commons-io commons-lang commons-lang3 commons-math3 commons-cli commons-csv drools-compiler drools-core ecj google-gson guava kie-api kie-internal log4j mvel2 optaplanner-core slf4j/api slf4j/log4j12 xstream xmlpull xpp3 protobuf reflections subscription-matcher) -server -Xmx2G ${EXTRA_ARGS} com.suse.matcher.Main "$@"


### PR DESCRIPTION
This patch is supposed to set the location of core dumps to `/var/crash` in case we are running on IBM Java to fix a part of [bsc#1107302](https://bugzilla.novell.com/show_bug.cgi?id=1107302). See also the [corresponding configuration for taskomatic in Uyuni](https://github.com/uyuni-project/uyuni/blob/master/java/conf/default/rhn_taskomatic_daemon.conf#L33-L37).