### PR TITLE
Fix merging of old style hard bundles

### DIFF
--- a/src/main/java/com/suse/matcher/FactConverter.java
+++ b/src/main/java/com/suse/matcher/FactConverter.java
@@ -113,7 +113,7 @@ public class FactConverter {
         Date timestamp = assignment.getProblemFactStream(Timestamp.class)
                 .findFirst().get().timestamp;
 
-        List<JsonMatch> confirmedMatches = getMatches(assignment, false);
+        List<JsonMatch> matches = getMatches(assignment, false);
 
         List<JsonMessage> messages = assignment.getProblemFactStream(Message.class)
                 .sorted()
@@ -133,7 +133,7 @@ public class FactConverter {
                         throwingMerger(),
                         LinkedHashMap::new));
 
-        return new JsonOutput(timestamp, confirmedMatches, messages, subscriptionPolicies);
+        return new JsonOutput(timestamp, matches, messages, subscriptionPolicies);
     }
 
     private static BinaryOperator<String> throwingMerger() {
@@ -186,7 +186,7 @@ public class FactConverter {
                 .append(a.getConfirmed(), b.getConfirmed())
                 .toComparison()
             )
-            .filter(m -> (!confirmedOnly) || m.getConfirmed())
+            .filter(m -> !confirmedOnly || m.getConfirmed())
             .collect(toList());
     }
 }

--- a/src/main/java/com/suse/matcher/facts/Subscription.java
+++ b/src/main/java/com/suse/matcher/facts/Subscription.java
@@ -102,7 +102,7 @@ public class Subscription implements Comparable<Subscription> {
     public Boolean ignored = false;
 
     /** The Hard Bundle Id that this subscription belongs to. If null, this doesn't belong to any Hard Bundle */
-    public Integer hardBundleId;
+    public Long hardBundleId;
 
     /** Does this subscription on its own represent a hard bundle? */
     public Boolean singleSubscriptionHardBundle = false;
@@ -232,7 +232,7 @@ public class Subscription implements Comparable<Subscription> {
     /**
      * @return Returns the hardBundleId.
      */
-    public Integer getHardBundleId() {
+    public Long getHardBundleId() {
         return hardBundleId;
     }
 
@@ -246,7 +246,7 @@ public class Subscription implements Comparable<Subscription> {
     /**
      * @param hardBundleId The hardBundleId to set.
      */
-    public void setHardBundleId(Integer hardBundleId) {
+    public void setHardBundleId(Long hardBundleId) {
         this.hardBundleId = hardBundleId;
     }
 

--- a/src/main/resources/com/suse/matcher/rules/drools/HardBundleConversion.drl
+++ b/src/main/resources/com/suse/matcher/rules/drools/HardBundleConversion.drl
@@ -4,57 +4,110 @@ import com.suse.matcher.facts.Message;
 import com.suse.matcher.facts.PinnedMatch;
 import com.suse.matcher.facts.Subscription;
 import com.suse.matcher.facts.SubscriptionProduct;
-import com.suse.matcher.facts.System;
 
 import java.util.TreeMap;
 
 // Agenda group for converting old style hard bundles (consisting of more subscriptions)
 // into a single-subscription hard bundle
 
-rule "mergeProducts"
+rule "markHardBundledCandidates"
     agenda-group "HardBundleConversion"
     when
-        Subscription(ignored == false, hardBundleId != null, $sub1HardBundleId : hardBundleId, $subToKeepId : id)
-        Subscription(id > $subToKeepId, hardBundleId == $sub1HardBundleId, $subToRetractId : id)
-        $subProd : SubscriptionProduct(subscriptionId == $subToRetractId);
+        // for a subscription we look for another subscription with same attributes
+        // if there is such a subscription, the original subscription is a hard bundle candidate
+        $candidate : Subscription(ignored == false, hardBundleId == null, singleSubscriptionHardBundle == false)
+        Subscription( // try to find subscription in the same hard bundle
+            id != $candidate.id,
+            ignored == false,
+            partNumber == $candidate.partNumber,
+            startDate == $candidate.startDate,
+            endDate == $candidate.endDate,
+            quantity == $candidate.quantity,
+            singleSubscriptionHardBundle == false)
     then
-        // we cannot use modify() because subscriptionId is in hashCode, retract and insert instead
-        insert(new SubscriptionProduct($subToKeepId, $subProd.productId));
-        retract($subProd);
+        // each hard bundle candidate will start with hard bundle id equal to its own id, later we'll merge them together
+        modify ($candidate) {
+            hardBundleId = $candidate.id;
+        }
+end
+
+// MERGING HARD BUNDLES
+// For reproducibility,  we merge 2 hard bundles together such that the hard bundle with higher id gets merged
+// into the one with lower id. This way we make sure the hard bundle id is equal to the lowest
+// subscription ("leading subscription") id of all subscriptions in it.
+rule "mergeHardBundles"
+    agenda-group "HardBundleConversion"
+    when
+        // find 2 subscriptions with same attributes
+        $leadingSub : Subscription(hardBundleId == id, ignored == false)
+        $mergingSub : Subscription(ignored == false,
+            hardBundleId > $leadingSub.hardBundleId,
+            partNumber == $leadingSub.partNumber,
+            startDate == $leadingSub.startDate,
+            endDate == $leadingSub.endDate,
+            quantity == $leadingSub.quantity)
+
+        // when the products of subscriptions are disjoint
+        not (
+            SubscriptionProduct(subscriptionId == $leadingSub.id, $productId : productId)  and
+            SubscriptionProduct(subscriptionId == $mergingSub.id, productId == $productId)
+        )
+
+        // .. and the products of the subscription to be merged are not empty
+        accumulate(
+            $mergingSP : SubscriptionProduct(subscriptionId == $mergingSub.id);
+            $mergingSPs : collectSet($mergingSP),
+            $count : count($mergingSP);
+            $count > 0
+        )
+    then
+        // ... we "merge" mergingSub hard bundle to leading subscription
+        modify($mergingSub) {
+            hardBundleId = $leadingSub.hardBundleId;
+        }
+        modify ($leadingSub) {
+            setSingleSubscriptionHardBundle(true)
+        }
+
+        for (Object mergingSP : $mergingSPs) {
+            insert(new SubscriptionProduct($leadingSub.id, ((SubscriptionProduct) mergingSP).getProductId()));
+            retract(mergingSP);
+        }
 end
 
 rule "mergePinnedMatches"
     agenda-group "HardBundleConversion"
     when
-        Subscription(ignored == false, hardBundleId != null, $subToKeepHBId : hardBundleId, $subToKeepId : id)
-        Subscription(id > $subToKeepId, hardBundleId == $subToKeepHBId, $subToRetractId : id)
+        // id of the "main" subscription in the hard bundle is equal to the hard bundle id
+        Subscription(ignored == false, hardBundleId == id, $hardBundleId : hardBundleId)
+        Subscription(ignored == false, id != $hardBundleId, hardBundleId == $hardBundleId, $subToRetractId : id)
         $pinnedMatch : PinnedMatch(subscriptionId == $subToRetractId)
     then
         TreeMap<String, String> data = new TreeMap<>();
         data.put("old_subscription_id", $subToRetractId.toString());
-        data.put("new_subscription_id", $subToKeepId.toString());
+        data.put("new_subscription_id", $hardBundleId.toString());
         data.put("system_id", $pinnedMatch.systemId.toString());
         insert(new Message(Message.Level.DEBUG, "hb_adjust_pinned_match", data));
 
         // we cannot use modify() because of attributes in hashCode, retract and insert instead
-        insert(new PinnedMatch($pinnedMatch.systemId, $subToKeepId));
+        insert(new PinnedMatch($pinnedMatch.systemId, $hardBundleId));
         retract($pinnedMatch);
 end
 
 rule "removeRedundantSubscriptions"
     agenda-group "HardBundleConversion"
     when
-        $subToKeep: Subscription(ignored == false, hardBundleId != null)
-        $subToRetract : Subscription(id > $subToKeep.id, hardBundleId == $subToKeep.hardBundleId)
+        // out all of the subscriptions in a hard bundle, we keep the one with lowest id
+        $leadingSub: Subscription(ignored == false, hardBundleId == id, singleSubscriptionHardBundle == true)
+        $subToRetract : Subscription(ignored == false, id > $leadingSub.id, hardBundleId == $leadingSub.hardBundleId)
     then
         TreeMap<String, String> data = new TreeMap<>();
         data.put("old_subscription_id", $subToRetract.id.toString());
-        data.put("new_subscription_id", $subToKeep.id.toString());
+        data.put("new_subscription_id", $leadingSub.id.toString());
         insert(new Message(Message.Level.INFO, "hb_merge_subscriptions", data));
 
-        modify($subToKeep) {
-            setName($subToKeep.name + " + " + $subToRetract.name),
-            setSingleSubscriptionHardBundle(true)
+        modify($leadingSub) {
+            name = $leadingSub.name + " + " + $subToRetract.name
         }
         retract($subToRetract);
 end

--- a/src/main/resources/com/suse/matcher/rules/drools/InputAugmenting.drl
+++ b/src/main/resources/com/suse/matcher/rules/drools/InputAugmenting.drl
@@ -38,27 +38,3 @@ rule "generatePenaltyGroups"
         insert(new PenaltyGroup(penaltyGroupId, $guestId));
 end
 
-rule "markHardBundledSubscriptions"
-    agenda-group "InputAugmenting"
-    when
-        // two subscriptions with different product sets, but otherwise identical, are by definition hard bundled
-        $s1 : Subscription(ignored == false)
-        $s2 : Subscription(ignored == false, partNumber == $s1.partNumber, id > $s1.id, startDate == $s1.startDate, endDate == $s1.endDate, quantity == $s1.quantity)
-        (
-            SubscriptionProduct($productId : productId, subscriptionId == $s1.id) and
-            not SubscriptionProduct(productId == $productId, subscriptionId == $s2.id)
-        ) or
-        (
-            SubscriptionProduct($productId : productId, subscriptionId == $s2.id) and
-            not SubscriptionProduct(productId == $productId, subscriptionId == $s1.id)
-        )
-    then
-        int hardBundleId = Drools.generateId($s1.partNumber, $s1.startDate, $s1.endDate, $s1.quantity);
-        modify($s1) {
-            hardBundleId = hardBundleId;
-        }
-        modify($s2) {
-            hardBundleId = hardBundleId;
-        }
-end
-

--- a/src/main/resources/com/suse/matcher/rules/drools/Matchability.drl
+++ b/src/main/resources/com/suse/matcher/rules/drools/Matchability.drl
@@ -167,7 +167,6 @@ rule "mergeCentGroupsInBundles"
             productId != $match1.productId
         )
         Product(id == $match2.productId, productClass != $match1prodClass, productClass != null)
-        Subscription(id == $match2.subscriptionId, singleSubscriptionHardBundle == true)
 
         CentGroup(id == $match1.centGroupId, $cents : cents)
         CentGroup(id == $match2.centGroupId, cents == $cents)

--- a/src/test/resources/scenario36/README.md
+++ b/src/test/resources/scenario36/README.md
@@ -3,7 +3,7 @@ Scenario 36 - single Subscription HardBundle with two subscriptions
 
 SUBSCRIPTIONS:
 - 1 subscription for SUSE Manager Server (product ids 1518, 1357) singleSubscriptionHardBundle
-- 1 (invalid) subscription for SLES (product id 1357)
+- 1 subscription for SLES (product id 1357)
 
 SYSTEMS:
 - 1 physical system with SUMA Server 3.1 and SLES12 SP2 installed (system id 100)
@@ -17,16 +17,16 @@ PINS:
 
 HARD-BUNDLE:
 - 1 with part number 874-005943 [INSTANCE]
-- 1 with part number 874-005943 [INSTANCE] for SLES
-
 
 Result
 ------
 
 The HardBundle has a subscription with 2 products of different product classes.
 
-But we got also a SLES subscription with same part number. These subscriptions will be merged.
-This scenario should fully match that one system with both products.
+But we got also a SLES subscription with same part number. These subscriptions
+won't be merged since they don't have disjoint product sets.
+This scenario should fully match that one system with both products using the
+subscription 1. The subscription 2 is left unused.
 
 System[100]
  - Subscription --> SLES12SP2[1357] + SUMAP3.1[1520]

--- a/src/test/resources/scenario36/output.json
+++ b/src/test/resources/scenario36/output.json
@@ -14,18 +14,18 @@
           "product_id": 1518,
           "cents": 50,
           "confirmed": true
+      },
+      {
+          "system_id": 100,
+          "subscription_id": 2,
+          "product_id": 1518,
+          "cents": 100,
+          "confirmed": false
       }
   ],
   "subscription_policies": {
-    "1": "instance"
+    "1": "instance",
+    "2": "instance"
   },
-  "messages": [
-      {
-        "type": "hb_merge_subscriptions",
-        "data": {
-          "new_subscription_id": "1",
-          "old_subscription_id": "2"
-        }
-      }
-  ]
+  "messages": []
 }

--- a/src/test/resources/scenario37/output.json
+++ b/src/test/resources/scenario37/output.json
@@ -45,14 +45,6 @@
           "type": "hb_adjust_pinned_match",
           "data": {
               "new_subscription_id": "1",
-              "old_subscription_id": "2",
-              "system_id": "100"
-          }
-      },
-      {
-          "type": "hb_adjust_pinned_match",
-          "data": {
-              "new_subscription_id": "2",
               "old_subscription_id": "3",
               "system_id": "100"
           }

--- a/src/test/resources/scenario38/README.md
+++ b/src/test/resources/scenario38/README.md
@@ -1,0 +1,43 @@
+Scenario 38 - 2 sets of HardBundles each with 2 subscriptions applied on full-matched physical systems
+======================================================================================================
+
+SUBSCRIPTIONS:
+- 2 subscriptions for SLES11 (product id 1298)
+- 2 subscriptions for SUSE Manager Server (product id 1224)
+
+SYSTEMS:
+- 3 physical systems with all products installed
+
+PRODUCTS:
+- id 1298: base SLES11 SP4 i686
+- id 1224: add-on SUSE Manager Server 2.1
+
+PINS:
+- Subscription 4 - System 100
+- Subscription 2 - System 101
+
+HARD-BUNDLE:
+- 2 x the same bundle, part number 874-006260
+
+Result
+------
+The test is about merging old style hard bundles into a single subscriptions
+hard bundles. Here we have 2 sets of subscriptions as follows:
+
+All subscriptions have equal part number, start/end date and quantity
+Subscription 1 - Product 1298
+Subscription 2 - Product 1224
+Subscription 3 - Product 1298
+Subscription 4 - Product 1224
+
+There are 2 interchangeable hard bundle configurations:
+1. HB1: Merged subscription 1 + 2
+   HB2: Merged subscription 3 + 4
+2. HB1: Merged subscription 1 + 4
+   HB2: Merged subscription 3 + 2
+
+After merge, we get 2 subscriptions, both with quantity = 1. Two systems should
+be covered.
+
+Pinned matches are added to test their correct merging.
+

--- a/src/test/resources/scenario38/input.json
+++ b/src/test/resources/scenario38/input.json
@@ -1,0 +1,104 @@
+{
+    "timestamp": "2015-05-01T00:00:00.000+0200",
+    "pinned_matches": [
+	{
+	    "subscription_id": 4,
+	    "system_id": 100
+	},
+	{
+	    "subscription_id": 2,
+	    "system_id": 101
+	}
+    ],
+    "products": [
+        {
+            "id": 1298,
+            "name": "SUSE Linux Enterprise Server 11 SP4 i686",
+            "base": true,
+            "product_class": "1"
+        },
+        {
+            "id": 1224,
+            "name": "SUSE Manager Server 2.1",
+            "base": true,
+            "product_class": "2"
+        }
+    ],
+    "subscriptions": [
+        {
+            "end_date": "2020-07-31T00:00:00Z",
+            "id": 1,
+            "part_number": "874-006260",
+            "product_ids": [
+                1298
+            ],
+            "quantity": 1,
+            "scc_username": "UC7",
+            "start_date": "2015-01-01T00:00:00Z"
+        },
+        {
+            "end_date": "2020-07-31T00:00:00Z",
+            "id": 2,
+            "part_number": "874-006260",
+            "product_ids": [
+                1224
+            ],
+            "quantity": 1,
+            "scc_username": "UC7",
+            "start_date": "2015-01-01T00:00:00Z"
+        },
+        {
+            "end_date": "2020-07-31T00:00:00Z",
+            "id": 3,
+            "part_number": "874-006260",
+            "product_ids": [
+                1298
+            ],
+            "quantity": 1,
+            "scc_username": "UC7",
+            "start_date": "2015-01-01T00:00:00Z"
+        },
+        {
+            "end_date": "2020-07-31T00:00:00Z",
+            "id": 4,
+            "part_number": "874-006260",
+            "product_ids": [
+                1224
+            ],
+            "quantity": 1,
+            "scc_username": "UC7",
+            "start_date": "2015-01-01T00:00:00Z"
+        }
+
+    ],
+    "virtualization_groups": [],
+    "systems": [
+        {
+            "cpus": 2,
+            "id": 100,
+            "physical": true,
+            "product_ids": [
+                1224, 1298
+            ],
+            "virtual_system_ids" : []
+        },
+        {
+            "cpus": 2,
+            "id": 101,
+            "physical": true,
+            "product_ids": [
+                1224, 1298
+            ],
+            "virtual_system_ids" : []
+        },
+	{
+            "cpus": 2,
+            "id": 102,
+            "physical": true,
+            "product_ids": [
+                1224, 1298
+            ],
+            "virtual_system_ids" : []
+        }
+    ]
+}

--- a/src/test/resources/scenario38/output.json
+++ b/src/test/resources/scenario38/output.json
@@ -1,0 +1,125 @@
+{
+  "timestamp": "2015-05-01T00:00:00.000+02",
+  "matches": [
+      {
+	  "system_id": 100,
+	  "subscription_id": 1,
+	  "product_id": 1224,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 100,
+	  "subscription_id": 3,
+	  "product_id": 1224,
+	  "cents": 50,
+	  "confirmed": true
+      },
+      {
+	  "system_id": 100,
+	  "subscription_id": 1,
+	  "product_id": 1298,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 100,
+	  "subscription_id": 3,
+	  "product_id": 1298,
+	  "cents": 50,
+	  "confirmed": true
+      },
+      {
+	  "system_id": 101,
+	  "subscription_id": 1,
+	  "product_id": 1224,
+	  "cents": 50,
+	  "confirmed": true
+      },
+      {
+	  "system_id": 101,
+	  "subscription_id": 3,
+	  "product_id": 1224,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 101,
+	  "subscription_id": 1,
+	  "product_id": 1298,
+	  "cents": 50,
+	  "confirmed": true
+      },
+      {
+	  "system_id": 101,
+	  "subscription_id": 3,
+	  "product_id": 1298,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 102,
+	  "subscription_id": 1,
+	  "product_id": 1224,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 102,
+	  "subscription_id": 3,
+	  "product_id": 1224,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 102,
+	  "subscription_id": 1,
+	  "product_id": 1298,
+	  "cents": 100,
+	  "confirmed": false
+      },
+      {
+	  "system_id": 102,
+	  "subscription_id": 3,
+	  "product_id": 1298,
+	  "cents": 100,
+	  "confirmed": false
+      }
+  ],
+  "subscription_policies": {
+    "1": "physical_only",
+    "3": "physical_only"
+  },
+  "messages": [
+      {
+	  "type": "hb_adjust_pinned_match",
+	  "data": {
+	      "new_subscription_id": "1",
+	      "old_subscription_id": "2",
+	      "system_id": "101"
+	  }
+      },
+      {
+	  "type": "hb_adjust_pinned_match",
+	  "data": {
+	      "new_subscription_id": "3",
+	      "old_subscription_id": "4",
+	      "system_id": "100"
+	  }
+      },
+      {
+          "type": "hb_merge_subscriptions",
+          "data": {
+              "new_subscription_id": "1",
+              "old_subscription_id": "2"
+          }
+      },
+      {
+          "type": "hb_merge_subscriptions",
+          "data": {
+              "new_subscription_id": "3",
+              "old_subscription_id": "4"
+          }
+      }
+  ]
+}


### PR DESCRIPTION
The old code was squashing old style hard bundles too much. See the commit message for the 'Old style hard bundle merging fix' commit.

## How to review
Commit-by-commit - the commit message are descriptive.

## Fixes (downstream issue)
https://github.com/SUSE/spacewalk/issues/6248
