### PR TITLE
Implement swap move

### DIFF
--- a/src/main/java/com/suse/matcher/MatchSwapMoveIterator.java
+++ b/src/main/java/com/suse/matcher/MatchSwapMoveIterator.java
@@ -1,0 +1,174 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.matcher;
+
+import static java.util.stream.Collectors.groupingBy;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+
+import com.suse.matcher.facts.PartialMatch;
+import com.suse.matcher.solver.Assignment;
+import com.suse.matcher.solver.Match;
+import com.suse.matcher.solver.MatchMove;
+
+import com.google.common.collect.Streams;
+
+import org.apache.commons.math3.util.Pair;
+import org.optaplanner.core.impl.heuristic.move.Move;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeMap;
+import java.util.stream.Collector;
+
+/**
+ * Generates {@link MatchMove}s.
+ *
+ * In particular, every {@link MatchMove} produced by this class will swap the confirmed flag
+ * of two {@link Match}es that have same subscription and different "confirmed" flag.
+ *
+ * All "confirmed" flags of incompatible {@link Match}es are flipped to false.
+ */
+public class MatchSwapMoveIterator implements Iterator<Move> {
+
+    /** Solution instance. */
+    private Assignment assignment;
+
+    /** Iterator over all matches. */
+    private final Iterator<Pair<PartialMatch, PartialMatch>> iterator;
+
+    /** Map from id to {@link Match}. */
+    private Map<Integer, Match> idMap;
+
+    /**
+     * Standard constructor.
+     * @param assignmentIn a solution instance
+     * @param randomIn a random number generator instance
+     */
+    public MatchSwapMoveIterator(Assignment assignmentIn, Random randomIn) {
+        assignment = assignmentIn;
+
+        List<Match> orderedMatches = new ArrayList<>(assignment.getMatches());
+
+        idMap = orderedMatches.stream()
+                .collect(toMap(
+                        match -> match.id,
+                        match -> match
+                ));
+
+        // subscription id -> confirmed/not confirmed -> shuffled list of matches
+        Map<Long, Map<Boolean, List<PartialMatch>>> subscriptionMatches = assignmentIn.getSortedPartialMatchesCache()
+                .stream()
+                .collect(groupingBy(
+                        pm -> pm.subscriptionId,
+                        TreeMap::new,
+                        groupingBy(
+                                pm -> idMap.get(pm.groupId).confirmed,
+                                TreeMap::new,
+                                toShuffledList(randomIn)
+                        )));
+
+        // subscription id -> list of pairs of matches containing the subscription, such that a confirmed match
+        // is on the left and not confirmed match is on the right in the match
+        Map<Long, List<Pair<PartialMatch, PartialMatch>>> zipped = zip(subscriptionMatches);
+
+        // transform to a list of [confirmed match, unconfirmed match] pairs of matches with same subscription
+        List<Pair<PartialMatch, PartialMatch>> pairs = zipped.values().stream().flatMap(c -> c.stream()).collect(toList());
+        Collections.shuffle(pairs, randomIn);
+        iterator = pairs.iterator();
+    }
+
+    // zip partial matches in the map into pairs of [confirmed, not confirmed] matches
+    private static Map<Long, List<Pair<PartialMatch, PartialMatch>>> zip(Map<Long, Map<Boolean, List<PartialMatch>>> map) {
+        return map.entrySet().stream()
+                .collect(toMap(
+                        e -> e.getKey(),
+                        e -> Streams.zip(
+                                e.getValue().getOrDefault(true, Collections.emptyList()).stream(),
+                                e.getValue().getOrDefault(false, Collections.emptyList()).stream(),
+                                (v1, v2) -> Pair.create(v1, v2)
+                        ).collect(toList())
+                ));
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public boolean hasNext() {
+        return iterator.hasNext();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public MatchMove next() {
+        // prepare MatchMove's lists
+        ArrayList<Match> matches = new ArrayList<>();
+        ArrayList<Boolean> states = new ArrayList<>();
+
+        // pick the matches to change
+        Pair<PartialMatch, PartialMatch> next = iterator.next();
+        Match match1 = idMap.get(next.getFirst().groupId);
+        Match match2 = idMap.get(next.getSecond().groupId);
+
+        // swap their "confirmed" flag
+        matches.add(match1);
+        states.add(match2.confirmed);
+        matches.add(match2);
+        states.add(match1.confirmed);
+
+        // also make sure any conflicting match is (flipped to) false
+        if (match2.confirmed) {
+            assignment.getConflictingMatchIds(match1.id)
+                    .map(id -> idMap.get(id))
+                    .filter(conflict -> conflict.confirmed)
+                    .forEach(conflict -> {
+                        matches.add(conflict);
+                        states.add(false);
+                    });
+        }
+
+        if (match1.confirmed) {
+            assignment.getConflictingMatchIds(match2.id)
+                    .map(id -> idMap.get(id))
+                    .filter(conflict -> conflict.confirmed)
+                    .forEach(conflict -> {
+                        matches.add(conflict);
+                        states.add(false);
+                    });
+        }
+
+        return new MatchMove(matches, states);
+    }
+
+    /**
+     * Custom toList collector that shuffles the list after creating it
+     *
+     * @param random the random numbers generator
+     * @param <T> the type of the list
+     * @return the shuffled list
+     */
+    private static <T> Collector<T, ?, List<T>> toShuffledList(Random random) {
+        return Collector.of(
+                ArrayList::new,
+                List::add,
+                (left, right) -> { left.addAll(right); return left; },
+                list -> { Collections.shuffle(list, random); return (List<T>) list; }
+        );
+    }
+}

--- a/src/main/java/com/suse/matcher/MatchSwapMoveIteratorFactory.java
+++ b/src/main/java/com/suse/matcher/MatchSwapMoveIteratorFactory.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright (c) 2019 SUSE LLC
+ *
+ * This software is licensed to you under the GNU General Public License,
+ * version 2 (GPLv2). There is NO WARRANTY for this software, express or
+ * implied, including the implied warranties of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. You should have received a copy of GPLv2
+ * along with this software; if not, see
+ * http://www.gnu.org/licenses/old-licenses/gpl-2.0.txt.
+ *
+ * Red Hat trademarks are not licensed under GPLv2. No permission is
+ * granted to use or replicate Red Hat trademarks that are incorporated
+ * in this software or its documentation.
+ */
+
+package com.suse.matcher;
+
+import com.suse.matcher.solver.Assignment;
+import com.suse.matcher.solver.MatchMoveIterator;
+
+import org.optaplanner.core.impl.heuristic.move.Move;
+import org.optaplanner.core.impl.heuristic.selector.move.factory.MoveIteratorFactory;
+import org.optaplanner.core.impl.score.director.ScoreDirector;
+
+import java.util.Iterator;
+import java.util.Random;
+
+public class MatchSwapMoveIteratorFactory implements MoveIteratorFactory {
+
+    /** {@inheritDoc} */
+    @Override
+    public long getSize(ScoreDirector director) {
+        // we generate exactly one move per Match
+        return getAssignment(director).getMatches().size();
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterator<Move> createRandomMoveIterator(ScoreDirector director, Random random) {
+        return new MatchSwapMoveIterator(getAssignment(director), random);
+    }
+
+    /** {@inheritDoc} */
+    @Override
+    public Iterator<Move> createOriginalMoveIterator(ScoreDirector director) {
+        throw new UnsupportedOperationException("ORIGINAL selectionOrder is not supported.");
+    }
+
+    private Assignment getAssignment(ScoreDirector director) {
+        return (Assignment)director.getWorkingSolution();
+    }
+}

--- a/src/main/java/com/suse/matcher/Matcher.java
+++ b/src/main/java/com/suse/matcher/Matcher.java
@@ -82,8 +82,12 @@ public class Matcher {
         // this is used by the CSP solver to avoid bad solutions
         Map<Integer, List<List<Integer>>> conflictMap = getConflictMap(deducedFacts);
 
+        // compute sorted partial matches for caching
+        List<PartialMatch> sortedPartialMatches = getPartialMatches(deducedFacts).sorted().distinct().collect(toList());
+
         // activate the CSP solver with all deduced facts as inputs
-        OptaPlanner optaPlanner = new OptaPlanner(new Assignment(matches, deducedFacts, conflictMap), testing);
+        OptaPlanner optaPlanner = new OptaPlanner(
+                new Assignment(matches, deducedFacts, conflictMap, sortedPartialMatches), testing);
         Assignment result = optaPlanner.getResult();
 
         // add user messages taking rule engine deductions and CSP solver output into account

--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -224,12 +224,12 @@ public class OptaPlanner {
          * Continue stepping and keep track of the overall best solution found so far.
          *
          * At some point we have to stop stepping, and we do so when:
-         *   - we stepped 100 times with no score improvement (typically)
+         *   - we stepped 200 times with no score improvement (typically)
          *   - we stepped 15_000 times (when all else fails)
          *   - we spent 1 hour finding the solution
          */
         TerminationConfig termination = new TerminationConfig();
-        termination.setUnimprovedStepCountLimit(100);
+        termination.setUnimprovedStepCountLimit(200);
         termination.setStepCountLimit(15_000);
         termination.setHoursSpentLimit(1L);
         search.setTerminationConfig(termination);
@@ -241,7 +241,7 @@ public class OptaPlanner {
          * Also activate OptaPlanner full assertions to catch more issues.
          */
         if (testing) {
-            termination.setUnimprovedStepCountLimit(6);
+            termination.setUnimprovedStepCountLimit(12);
             config.setEnvironmentMode(EnvironmentMode.FULL_ASSERT);
         }
 

--- a/src/main/java/com/suse/matcher/OptaPlanner.java
+++ b/src/main/java/com/suse/matcher/OptaPlanner.java
@@ -16,6 +16,7 @@ import org.optaplanner.core.config.heuristic.selector.common.SelectionCacheType;
 import org.optaplanner.core.config.heuristic.selector.common.SelectionOrder;
 import org.optaplanner.core.config.heuristic.selector.entity.EntitySelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.MoveSelectorConfig;
+import org.optaplanner.core.config.heuristic.selector.move.composite.UnionMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.move.factory.MoveIteratorFactoryConfig;
 import org.optaplanner.core.config.heuristic.selector.move.generic.ChangeMoveSelectorConfig;
 import org.optaplanner.core.config.heuristic.selector.value.ValueSelectorConfig;
@@ -35,6 +36,7 @@ import org.slf4j.LoggerFactory;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.List;
 
 /**
  * Facade on the OptaPlanner solver.
@@ -175,19 +177,30 @@ public class OptaPlanner {
          *
          * For more information about how those moves are generated see the MatchMoveIteratorFactory class.
          */
-        LocalSearchPhaseConfig search = new LocalSearchPhaseConfig();
         MoveIteratorFactoryConfig move = new MoveIteratorFactoryConfig();
         move.setCacheType(SelectionCacheType.JUST_IN_TIME);
         move.setSelectionOrder(SelectionOrder.RANDOM);
         move.setMoveIteratorFactoryClass(MatchMoveIteratorFactory.class);
+        move.setSelectedCountLimit(10_000L);
+
+        MoveIteratorFactoryConfig swapMove = new MoveIteratorFactoryConfig();
+        swapMove.setCacheType(SelectionCacheType.JUST_IN_TIME);
+        swapMove.setSelectionOrder(SelectionOrder.RANDOM);
+        swapMove.setMoveIteratorFactoryClass(MatchSwapMoveIteratorFactory.class);
+        swapMove.setSelectedCountLimit(10_000L);
 
         /*
-         * Every step, generate several moves and pick the best scoring one as the next step.
-         *
-         * As possible moves might be a lot, don't generate more than 10_000 in any case.
+         * Union move uses both of the above move implementations:
+         * both moves alternate within the step (in random fashion).
          */
-        move.setSelectedCountLimit(10_000L);
-        search.setMoveSelectorConfig(move);
+        UnionMoveSelectorConfig unionMoveConfig = new UnionMoveSelectorConfig();
+        List<MoveSelectorConfig> selectors = new ArrayList<>();
+        selectors.add(move);
+        selectors.add(swapMove);
+        unionMoveConfig.setMoveSelectorConfigList(selectors);
+
+        LocalSearchPhaseConfig search = new LocalSearchPhaseConfig();
+        search.setMoveSelectorConfig(unionMoveConfig);
 
         /*
          * Among generated moves, don't accept moves that were already attempted in the last

--- a/src/main/java/com/suse/matcher/solver/Assignment.java
+++ b/src/main/java/com/suse/matcher/solver/Assignment.java
@@ -1,5 +1,7 @@
 package com.suse.matcher.solver;
 
+import com.suse.matcher.facts.PartialMatch;
+
 import org.optaplanner.core.api.domain.solution.PlanningEntityCollectionProperty;
 import org.optaplanner.core.api.domain.solution.PlanningSolution;
 import org.optaplanner.core.api.domain.solution.Solution;
@@ -32,6 +34,9 @@ public class Assignment implements Solution<HardSoftScore> {
     /** Maps every {@link Match} id to all conflicting sets where it appears. */
     private Map<Integer, List<List<Integer>>> conflictMap;
 
+    /** Cache of sorted partial matches. */
+    private List<PartialMatch> sortedPartialMatchesCache;
+
     /**
      * Default constructor, required by OptaPlanner.
      */
@@ -44,12 +49,14 @@ public class Assignment implements Solution<HardSoftScore> {
      * @param matchesIn fact corresponding to possible matches
      * @param problemFactsIn any other problem facts
      * @param conflictMapIn maps every {@link Match} id to any conflicting sets where it appears
+     * @param sortedPartialMatchesIn sorted partial matches
      */
     public Assignment(List<Match> matchesIn, Collection<Object> problemFactsIn,
-            Map<Integer, List<List<Integer>>> conflictMapIn) {
+            Map<Integer, List<List<Integer>>> conflictMapIn, List<PartialMatch> sortedPartialMatchesIn) {
         matches = matchesIn;
         problemFacts = problemFactsIn;
         conflictMap = conflictMapIn;
+        sortedPartialMatchesCache = sortedPartialMatchesIn;
     }
 
     /**
@@ -60,6 +67,15 @@ public class Assignment implements Solution<HardSoftScore> {
         // those will be inserted in the private OptaPlanner Drools instance
         // so that they can be used in score rules
         return problemFacts;
+    }
+
+    /**
+     * Gets the sortedPartialMatches cache.
+     *
+     * @return sortedPartialMatches
+     */
+    public List<PartialMatch> getSortedPartialMatchesCache() {
+        return sortedPartialMatchesCache;
     }
 
     /**

--- a/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
+++ b/src/main/resources/com/suse/matcher/rules/optaplanner/Scores.drl
@@ -104,7 +104,7 @@ rule "preferBundledMatches"
         PartialMatch($groupId : groupId, $systemId : systemId, $centGroupId : centGroupId)
         PartialMatch($groupId2 : groupId, systemId == $systemId, centGroupId == $centGroupId)
         Match(id == $groupId, confirmed == true)
-        Match(id == $groupId2, id > $groupId, confirmed == true)
+        Match(id == $groupId2, id != $groupId)
     then
         scoreHolder.addSoftConstraintMatch(kcontext, 1);
 end


### PR DESCRIPTION
## Motivation
With current move implementation (in `MatchMoveIterator`, which is essentially a "change move aware of conflicting matches"), it's hard for OptaPlanner to unstuck itself from solutions where a particular subcribtion is fully used-up. In such situation, if there exists a better solution, which involves assigning such subscription to other system/product (bundles), it's impossible for the matcher to "unconfirm" some confirmed match and confirm some other one. This would mean 2 steps:
- step 1. "unconfirm" a match
- step 2. confirm another one

This doesn't work since the step 1. would lead to decreasing of the softscore and corresponding move wouldn't be accepted. The bottom line is: as soon as matcher confirms a subscription, it's impossible for it to revert this.

Such situations happened after construction heuristics finished - often, the local search couldn't achieve a better result than the result of the construction heuristicts.

## Suggested solution
Implement a swap move that takes 2 matches with same subscription and inverse `confirmed` flag and swap their `confirmed` flag. With such move, matcher can explore solutions where a subscription can be matched to a different product/system even if it's already fully matched.

## Alternative solution
Use some method that allows temporary softscore decreasing. E.g. "late acceptance" could be used (even as a complement to this PR!).

We already use a local-optima-avoiding strategy: tabu. I was able to solve the stuck situation with over-tuning tabu and unimproved steps count parameters which lead to horrible performance.

## Implementation
`MatchSwapMoveIterator` implements the move. Optaplanner than utilizes together with the original change move via the "union move": change moves and swap moves are used in alternative fashion within steps.

Unimproved steps limit was also tuned.

## Performance
17 % slowdown over our "big" test data.