### PR TITLE
Utilize github CI

### DIFF
--- a/.github/workflows/maven.yml
+++ b/.github/workflows/maven.yml
@@ -1,0 +1,17 @@
+name: Java CI
+
+on: [push]
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up JDK 1.8
+      uses: actions/setup-java@v1
+      with:
+        java-version: 1.8
+    - name: Build with Maven
+      run: mvn -B package --file pom.xml


### PR DESCRIPTION
Use github CI for running test on PRs.

the `mvn package` goal (which in turn runs the `test` goal) is run on each PR, detecting possible errors.

- An example of a broken PR behavior: https://github.com/openSUSE/subscription-matcher/pull/16
- An example of passing PR: this one